### PR TITLE
fix: app-root-path for proto-loader does not work when the project is…

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('../build/src/index.js');
+require('../build/index.js');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commentcov/commentcov-plugin-typescript",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "engines": {
     "node": ">=16.0.0"
   },
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "https://github.com/commentcov/commentcov-plugin-typescript.git"
   },
-  "main": "build/src/index.js",
+  "main": "build/index.js",
   "devDependencies": {
     "@types/app-root-path": "^1.2.4",
     "@types/google-protobuf": "^3.15.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import rootDir from 'app-root-path';
 import * as grpc from '@grpc/grpc-js';
 import * as protoLoader from '@grpc/proto-loader';
 import wrapServerWithReflection from 'grpc-node-server-reflection';
+import path from 'path';
 
 import {ServingStatus} from './module';
 import {HealthProtoGrpcType} from './module';
@@ -11,11 +11,17 @@ import {pluginImplementation} from './module';
 import {sleep} from './module';
 
 /**
+ * root path of the project.
+ * @type {string}
+ */
+const rootPath = path.resolve(__dirname, '..');
+
+/**
  * HealthCheck Service Definition.
  * @type {grpc.GrpcObject}
  */
 const healthProto = grpc.loadPackageDefinition(
-  protoLoader.loadSync(`${rootDir}/grpc.health.v1/health.proto`)
+  protoLoader.loadSync(rootPath + '/grpc.health.v1/health.proto')
 ) as unknown as HealthProtoGrpcType;
 
 initStatusMap({
@@ -27,7 +33,7 @@ initStatusMap({
  * @type {grpc.GrpcObject}
  */
 const commentcovPluginProto = grpc.loadPackageDefinition(
-  protoLoader.loadSync(`${rootDir}/commentcov-proto/commentcov_plugin.proto`)
+  protoLoader.loadSync(rootPath + '/commentcov-proto/commentcov_plugin.proto')
 ) as unknown as CommentcovPluginProtoGrpcType;
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,11 +15,11 @@
     "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
+    "outDir": "./build",
+    "rootDir": "./src",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "noImplicitAny": true,
-    "outDir": "./build",
-    "rootDir": ".",
     "strict": true,
     "forceConsistentCasingInFileNames": true
   },


### PR DESCRIPTION
… installed in node_modules